### PR TITLE
Clear module configuration cache when enabling dev mode

### DIFF
--- a/DevelopmentModeController.php
+++ b/DevelopmentModeController.php
@@ -12,6 +12,22 @@ use Zend\Mvc\Controller\AbstractActionController;
 
 class DevelopmentModeController extends AbstractActionController
 {
+    const CONFIG_CACHE_BASE = 'module-config-cache';
+
+    /**
+     * @param string Configuration cache directory, if any
+     */
+    private $configCacheDir;
+
+    /**
+     * @param string Configuration cache key, if any
+     */
+    private $configCacheKey;
+
+    public function __construct($configCacheDir, $configCacheKey)
+    {
+    }
+
     public function setEventManager(EventManagerInterface $events)
     {
         parent::setEventManager($events);
@@ -40,10 +56,14 @@ class DevelopmentModeController extends AbstractActionController
 
         copy('config/development.config.php.dist', 'config/development.config.php');
 
-
         if (file_exists('config/autoload/development.local.php.dist')) {
             // optional application config override
             copy('config/autoload/development.local.php.dist', 'config/autoload/development.local.php');
+        }
+
+        $configCacheFile = $this->getConfigCacheFile();
+        if ($configCacheFile && file_exists($configCacheFile)) {
+            unlink($configCacheFile);
         }
 
         return "You are now in development mode.\n";
@@ -63,5 +83,25 @@ class DevelopmentModeController extends AbstractActionController
 
         unlink('config/development.config.php');
         return "Development mode is now disabled.\n";
+    }
+
+    /**
+     * Retrieve the config cache file, if any.
+     * 
+     * @return false|string
+     */
+    private function getConfigCacheFile()
+    {
+        if (empty($this->configCacheDir)) {
+            return false;
+        }
+
+        $path = sprintf('%s/%s.', $this->configCacheDir, self::CONFIG_CACHE_BASE);
+
+        if (! empty($this->configCacheKey)) {
+            $path .= $this->configCacheKey . '.';
+        }
+
+        return $path . 'php';
     }
 }

--- a/DevelopmentModeController.php
+++ b/DevelopmentModeController.php
@@ -24,8 +24,14 @@ class DevelopmentModeController extends AbstractActionController
      */
     private $configCacheKey;
 
+    /**
+     * @param null|string $configCacheDir
+     * @param null|string $configCacheKey
+     */
     public function __construct($configCacheDir, $configCacheKey)
     {
+        $this->configCacheDir = $configCacheDir;
+        $this->configCacheKey = $configCacheKey;
     }
 
     public function setEventManager(EventManagerInterface $events)

--- a/DevelopmentModeController.php
+++ b/DevelopmentModeController.php
@@ -93,7 +93,7 @@ class DevelopmentModeController extends AbstractActionController
 
     /**
      * Retrieve the config cache file, if any.
-     * 
+     *
      * @return false|string
      */
     private function getConfigCacheFile()

--- a/DevelopmentModeControllerFactory.php
+++ b/DevelopmentModeControllerFactory.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\DevelopmentMode;
+
+class DevelopmentModeControllerFactory
+{
+    public function __invoke($controllers)
+    {
+        $configCacheDir = null;
+        $configCacheKey = null;
+        $services       = $controllers->getServiceLocator();
+
+        if ($services->has('ApplicationConfig')) {
+            $config = $services->get('ApplicationConfig');
+            if (isset($config['cache_dir']) && ! empty($config['cache_dir'])) {
+                $configCacheDir = $config['cache_dir'];
+            }
+            if (isset($config['config_cache_key']) && ! empty($config['config_cache_key'])) {
+                $configCacheKey = $config['config_cache_key'];
+            }
+        }
+
+        return new DevelopmentModeController($configCacheDir, $configCacheKey);
+    }
+}

--- a/Module.php
+++ b/Module.php
@@ -14,8 +14,9 @@ class Module
     {
         return array(
             'controllers' => array(
-                'invokables' => array(
-                    'ZF\DevelopmentMode\DevelopmentModeController' => 'ZF\DevelopmentMode\DevelopmentModeController',
+                'factories' => array(
+                    'ZF\DevelopmentMode\DevelopmentModeController' =>
+                        'ZF\DevelopmentMode\DevelopmentModeControllerFactory',
                 ),
             ),
             'console' => array(

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ cd path/to/install
 php public/index.php development enable
 ```
 
+Note: enabling development mode will also clear your module configuation cache,
+to allow safely updating dependencies and ensuring any new configuration is
+picked up by your application.
+
 To disable development mode
 ---------------------------
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "autoload": {
         "classmap": [
             "./Module.php",
-            "./DevelopmentModeController.php"
+            "./DevelopmentModeController.php",
             "./DevelopmentModeControllerFactory.php"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "classmap": [
             "./Module.php",
             "./DevelopmentModeController.php"
+            "./DevelopmentModeControllerFactory.php"
         ]
     },
     "extra": {


### PR DESCRIPTION
[zfcampus/zf-apigility-skeleton#70](https://github.com/zfcampus/zf-apigility-skeleton/pull/70)
enables configuration caching when in production mode. This can cause problems
when you update dependencies, as any configuration changes will not be picked
up. This patch detects if configuration caching is present, and will remove the
configuration cache when enabling development mode.