### PR TITLE
Remove the development cache file on all actions

### DIFF
--- a/DevelopmentModeController.php
+++ b/DevelopmentModeController.php
@@ -67,10 +67,7 @@ class DevelopmentModeController extends AbstractActionController
             copy('config/autoload/development.local.php.dist', 'config/autoload/development.local.php');
         }
 
-        $configCacheFile = $this->getConfigCacheFile();
-        if ($configCacheFile && file_exists($configCacheFile)) {
-            unlink($configCacheFile);
-        }
+        $this->removeConfigCacheFile($this->getConfigCacheFile());
 
         return "You are now in development mode.\n";
     }
@@ -88,7 +85,21 @@ class DevelopmentModeController extends AbstractActionController
         }
 
         unlink('config/development.config.php');
+
+        $this->removeConfigCacheFile($this->getConfigCacheFile());
+
         return "Development mode is now disabled.\n";
+    }
+
+    /**
+     * Removes the application configuration cache file, if present.
+     *
+     */
+    private function removeConfigCacheFile($configCacheFile)
+    {
+        if ($configCacheFile && file_exists($configCacheFile)) {
+            unlink($configCacheFile);
+        }
     }
 
     /**


### PR DESCRIPTION
Switching from development mode and back should always remove the application configuration cache file to ensure that changes are propagated properly.

Discovered when configuration cache files were accidently included in an Apigility skeleton app, where the last action performed was to enable development mode!