### PR TITLE
Use symlink instead of copy on whitelisted OSes

### DIFF
--- a/src/Enable.php
+++ b/src/Enable.php
@@ -72,7 +72,7 @@ class Enable
             return 1;
         }
 
-        copy($develConfigDist, $develConfig);
+        $this->copy($develConfigDist, $develConfig);
 
         $develLocalDist = $this->projectDir
             ? sprintf('%s/%s', $this->projectDir, self::DEVEL_LOCAL_DIST)
@@ -82,10 +82,35 @@ class Enable
             $develLocal = $this->projectDir
                 ? sprintf('%s/%s', $this->projectDir, self::DEVEL_LOCAL)
                 : self::DEVEL_LOCAL;
-            copy($develLocalDist, $develLocal);
+            $this->copy($develLocalDist, $develLocal);
         }
 
         echo 'You are now in development mode.', PHP_EOL;
         return 0;
+    }
+
+    /**
+     * Returns whether the OS support symlinks well enough.
+     *
+     * @return bool
+     */
+    protected function supportSymlinks()
+    {
+        return in_array(PHP_OS, ['Linux', 'Unix', 'Darwin']);
+    }
+
+    /**
+     * Copy, or symlink, the source to the destination.
+     *
+     * @param string $source
+     * @param string $destination
+     */
+    private function copy($source, $destination)
+    {
+        if ($this->supportSymlinks()) {
+            symlink(basename($source), $destination);
+        } else {
+            copy($source, $destination);
+        }
     }
 }

--- a/test/EnableTest.php
+++ b/test/EnableTest.php
@@ -35,7 +35,11 @@ class EnableTest extends TestCase
             'data' => [],
         ]);
         $this->errorStream = fopen('php://memory', 'w+');
-        $this->command = new Enable(vfsStream::url('project'), $this->errorStream);
+        $this->command = $this->getMockBuilder(Enable::class)
+            ->setConstructorArgs([vfsStream::url('project'), $this->errorStream])
+            ->setMethods(['supportSymlinks'])
+            ->getMock();
+        $this->command->method('supportSymlinks')->willReturn(false);
     }
 
     public function tearDown()


### PR DESCRIPTION
As discussed in #27 and asked by @webimpress.

Unfortunately [vfsStream does not support symlink](https://github.com/mikey179/vfsStream/wiki/Known-Issues), so we cannot cover that part with unit tests. But I did test it manually and it works as expected. If you have a suggestion on how to cover that by unit tests, please let me know.

