### PR TITLE
Added another path option to reach autoload.php

### DIFF
--- a/bin/zf-development-mode
+++ b/bin/zf-development-mode
@@ -13,6 +13,8 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
     require $a;
 } elseif (file_exists($a = __DIR__ . '/../vendor/autoload.php')) {
     require $a;
+} elseif (file_exists($a = __DIR__ . '/../autoload.php')) {
+    require $a;
 } else {
     fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
     exit(1);


### PR DESCRIPTION
Same issue as described [here](https://github.com/zendframework/zend-expressive-tooling/pull/28#issuecomment-300173700).

There is no symlink in macOS, just a copy of executable which cannot locate autoloader. But if we, for example, create project inside Docker container using Alpine 3.10 as base image, it creates symlink to `vendor/zfcampus/zf-development-mode/bin/zf-development-mode` and everything works fine as expected.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.